### PR TITLE
Small fixes

### DIFF
--- a/.gqlconfig
+++ b/.gqlconfig
@@ -1,5 +1,5 @@
 {
   schema: {
-    files: 'src/schema.graphql'
+    files: 'schema.graphql'
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "dev": "run-p '*/dev'",
     "database/mock": "ts-node src/database/mock.ts --project ./src",
     "build": "tsc --project ./src",
-    "debug": "tsc --project ./src --watch",
     "clean": "rm -rf ./dist",
     "start": "node dist/server.js",
     "validate-file-names": "validate-file-names",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev": "run-p '*/dev'",
     "database/mock": "ts-node src/database/mock.ts --project ./src",
     "build": "tsc --project ./src",
+    "debug": "tsc --project ./src --watch",
     "clean": "rm -rf ./dist",
     "start": "node dist/server.js",
     "validate-file-names": "validate-file-names",

--- a/schema.graphql
+++ b/schema.graphql
@@ -98,7 +98,7 @@ type CreateNotablePersonPayload {
 type RootMutation {
   # Create a new user using a valid Facebook access token
   # issued for the Hollowverse application.
-  # The name and email of the new user will be obtained from Facebook if
+  # The name of the new user will be obtained from Facebook if
   # not specified in the mutation input.
   createUser(input: CreateUserInput!): Viewer
   # Create a new entry for a notable person

--- a/schema.graphql
+++ b/schema.graphql
@@ -96,7 +96,7 @@ type CreateNotablePersonPayload {
 }
 
 type RootMutation {
-  # Create a new user passing using a valid Facebook access token
+  # Create a new user using a valid Facebook access token
   # issued for the Hollowverse application.
   # The name and email of the new user will be obtained from Facebook if
   # not specified in the mutation input.

--- a/src/database/entities/user.ts
+++ b/src/database/entities/user.ts
@@ -69,7 +69,7 @@ export class User extends BaseEntity {
 
   async validate() {
     if (typeof this.email === 'string' && isEmail(this.email)) {
-      this.email = normalizeEmail(this.email) || null;
+      this.email = normalizeEmail(this.email, { lowercase: true }) || null;
     }
 
     return super.validate();

--- a/src/helpers/formatError.ts
+++ b/src/helpers/formatError.ts
@@ -1,5 +1,6 @@
-import { GraphQLError } from 'graphql';
+import { GraphQLError } from 'graphql/error';
 import { ValidationError } from 'class-validator';
+import { QueryFailedError } from 'typeorm';
 import { ApiError } from './apiError';
 
 /**
@@ -8,7 +9,7 @@ import { ApiError } from './apiError';
  * 
  * This is used for error results in API queries
  */
-function pickSafeProps(error: Error | ValidationError | any) {
+function pickSafeProps(error: Error | ValidationError | QueryFailedError) {
   if (error instanceof ValidationError) {
     const { property, constraints } = error;
 
@@ -17,9 +18,9 @@ function pickSafeProps(error: Error | ValidationError | any) {
     // `ApiError` knows how to remove unsafe props. Just return it as-is.
     return error;
   } else {
-    const { name, code } = error;
+    const { name } = error;
 
-    return { name, code };
+    return { name };
   }
 }
 

--- a/src/resolvers/scalars/email.ts
+++ b/src/resolvers/scalars/email.ts
@@ -1,4 +1,4 @@
-import { GraphQLScalarType } from 'graphql';
+import { GraphQLScalarType } from 'graphql/type';
 import { ASTNode, Kind } from 'graphql/language';
 import { GraphQLError } from 'graphql/error';
 

--- a/src/resolvers/scalars/url.ts
+++ b/src/resolvers/scalars/url.ts
@@ -1,4 +1,4 @@
-import { GraphQLScalarType } from 'graphql';
+import { GraphQLScalarType } from 'graphql/type';
 import { ASTNode, Kind } from 'graphql/language';
 import { GraphQLError } from 'graphql/error';
 


### PR DESCRIPTION
* Do not display error.code in query result for privacy reasons: This could reveal whether a user is registered by attempting to `createUser` with the same email.
* Fix configuration of GraphQL extension for VS Code
* ~Add debug npm script to use with VS Code~ (no longer needed, #4 adds `--inspect` for debugging)
* Import from GraphQL submodules for consistency
* Lowercase user email address
* Fix comment in schema