### PR TITLE
Enhance Docker Compose workflow

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Docker: Attach to Node",
+        "type": "node",
+        "request": "attach",
+        "port": 9229,
+        "address": "127.0.0.1",
+        "localRoot": "${workspaceRoot}",
+        "remoteRoot": "/code",
+        "protocol": "inspector"
+      }
+    ]
+  }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9-alpine
+FROM node:8.9-alpine
 
 RUN apk update -q && apk add git -q
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM node:9-alpine
+FROM node:8.9-alpine
 
 RUN apk update -q && apk add git -q
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - database
     ports:
       - "${API_PORT:-8080}:8080"
-      - "${DEBUG_PORT:-9229}:9229"
+      - "${API_DEBUG_PORT:-9229}:9229"
     volumes:
       - type: bind
         source: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,14 @@ services:
   database:
     image: mysql
     restart: on-failure
+    volumes:
+      - type: volume
+        source: database
+        target: /var/lib/mysql
     ports:
-      - 3306:3306
+      - "3306:3306"
     expose:
-      - 3306
+      - "3306"
     environment:
       - MYSQL_DATABASE=hollowverse
       - MYSQL_ROOT_PASSWORD=123456
@@ -23,8 +27,8 @@ services:
     links:
       - database
     ports:
-      - 8080:8080
-      - 9229:9229
+      - "${API_PORT:-8080}:8080"
+      - "${DEBUG_PORT:-9229}:9229"
     volumes:
       - type: bind
         source: .
@@ -40,4 +44,6 @@ services:
 
 volumes:
   nm:
+  database:
+
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "generate-schema-types": "graphql-to-typescript schema.graphql src/typings/schema.ts",
     "generate-schema-types/dev": "nodemon --watch schema.graphql --exec 'run-p generate-schema-types'",
     "server/dev": "PORT=${API_PORT:-8080} nodemon --watch ./src --ext ts,graphql,tsx,json --exec 'node --inspect=0.0.0.0:${API_DEBUG_PORT:-9229} -r 'ts-node/register' src/server.ts'",
-    "dev": "run-p '*/dev'",
+    "dev": "npm-run-all -s generate-schema-types -p '*/dev'",
     "database/mock": "ts-node src/database/mock.ts --project ./src",
     "build": "tsc --project ./src",
     "clean": "rm -rf ./dist",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint-ts": "tslint './*.ts' 'src/**/*.ts{,x}' -e 'src/typings/schema.ts' --project tsconfig.json",
     "generate-schema-types": "graphql-to-typescript schema.graphql src/typings/schema.ts",
     "generate-schema-types/dev": "nodemon --watch schema.graphql --exec 'run-p generate-schema-types'",
-    "server/dev": "PORT=8080 nodemon --watch ./src --ext ts,graphql,tsx,json --exec 'node --inspect=0.0.0.0:9229 -r 'ts-node/register' src/server.ts'",
+    "server/dev": "PORT=${API_PORT:-8080} nodemon --watch ./src --ext ts,graphql,tsx,json --exec 'node --inspect=0.0.0.0:${API_DEBUG_PORT:-9229} -r 'ts-node/register' src/server.ts'",
     "dev": "run-p '*/dev'",
     "database/mock": "ts-node src/database/mock.ts --project ./src",
     "build": "tsc --project ./src",


### PR DESCRIPTION
* Use string syntax to define ports as recommended in Compose documentation to avoid edge case with YAML parser interpreting numbers like `xx:yy` as sexagesimal.
* Allow customizing API server port and debugging port via envirnoment variables (`API_PORT` and `ِAPI_DEBUG_PORT` respectively).
* Use a Docker managed volume to persist database data

## Tasks
* [x] Update Wiki to explain how to customize the ports