### PR TITLE
Update notable person example query

### DIFF
--- a/src/examples/notablePerson.graphql
+++ b/src/examples/notablePerson.graphql
@@ -2,6 +2,8 @@ query GetNotablePerson {
   notablePerson(slug: "Tom_Hanks") {
     slug
     name
+    summary
+    photoUrl
     events {
       id
       quote
@@ -9,6 +11,14 @@ query GetNotablePerson {
       isQuoteByNotablePerson
       postedAt
       happenedOn
+      comments {
+        owner {
+          id
+          name
+          photoUrl
+        }
+        text
+      }
     }
   }
 }


### PR DESCRIPTION
The operations in `src/exampels` are used to validate the schema on CI. This will help ensure that we do not introduce breaking changes to the schema (to a certain degree).