### PR TITLE
Use Facebook profile pictures for users and viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "class-sanitizer": "^0.0.5",
     "class-validator": "^0.7.2",
     "cors": "^2.8.4",
+    "dataloader": "^1.3.0",
     "express": "^4.15.2",
     "got": "^7.1.0",
     "graphql": "^0.11.7",

--- a/src/database/entities/user.ts
+++ b/src/database/entities/user.ts
@@ -1,18 +1,10 @@
-import {
-  Entity,
-  Column,
-  AfterLoad,
-  PrimaryGeneratedColumn,
-  OneToMany,
-} from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 import { IsEmail, IsNotEmpty, ValidateIf } from 'class-validator';
 import { Trim } from 'class-sanitizer';
 import { normalizeEmail, isEmail } from 'validator';
 import { BaseEntity } from './base';
 import { NotablePersonEvent } from './event';
 import { NotablePersonEventComment } from './comment';
-
-import { URL } from 'url';
 
 /**
  * A Hollowverse user
@@ -37,9 +29,6 @@ export class User extends BaseEntity {
   @Column({ type: 'text', nullable: true })
   photoId: string | null;
 
-  /** Photo URL computed from `photoId`, not an actual column. */
-  photoUrl: string;
-
   @OneToMany(_ => NotablePersonEvent, event => event.owner, {
     cascadeInsert: true,
     cascadeUpdate: true,
@@ -58,15 +47,6 @@ export class User extends BaseEntity {
   @IsNotEmpty()
   @Column({ type: 'varchar', nullable: false, unique: true })
   fbId: string;
-
-  @AfterLoad()
-  setPhotoUrl() {
-    this.photoUrl = new URL(
-      `users/${this.id}`,
-      'https://files.hollowverse.com',
-    ).toString();
-  }
-
   async validate() {
     if (typeof this.email === 'string' && isEmail(this.email)) {
       this.email = normalizeEmail(this.email, { lowercase: true }) || null;

--- a/src/helpers/facebook.ts
+++ b/src/helpers/facebook.ts
@@ -69,3 +69,18 @@ export async function sendFacebookAuthenticatedRequest(
         : options.query,
   });
 }
+
+export async function getPhotoUrlByFbId(
+  fbId: string,
+  type: 'small' | 'normal' | 'large' = 'normal',
+) {
+  const response = await got(`https://graph.facebook.com/${fbId}/picture`, {
+    json: true,
+    query: {
+      type: type,
+      redirect: false,
+    },
+  });
+
+  return response.body.data.url;
+}

--- a/src/helpers/facebook.ts
+++ b/src/helpers/facebook.ts
@@ -82,5 +82,5 @@ export async function getPhotoUrlByFbId(
     },
   });
 
-  return response.body.data.url;
+  return response.body.data.url as string;
 }

--- a/src/resolvers/mutations/createUser.ts
+++ b/src/resolvers/mutations/createUser.ts
@@ -16,7 +16,7 @@ export async function createUser(
   _: undefined,
   { input: { fbAccessToken, email, name } }: CreateUserRootMutationArgs,
   context: SchemaContext,
-): Promise<RootMutation['createUser']> {
+): Promise<Partial<RootMutation['createUser']>> {
   if (context.viewer) {
     throw new ApiError(
       'OperationNotAllowedError',

--- a/src/resolvers/resolvers.ts
+++ b/src/resolvers/resolvers.ts
@@ -7,6 +7,8 @@ import { notablePersonResolvers } from './queries/notablePerson';
 import { merge } from 'lodash';
 import { Email } from './scalars/email';
 import { Url } from './scalars/url';
+import { userResolvers } from './types/user';
+import { viewerResolvers } from './types/viewer';
 
 /**
  * Resolvers for custom scalar types.
@@ -30,6 +32,8 @@ export const resolvers = merge(
       createNotablePerson: requireAuthentication(createNotablePerson),
     },
   },
+  userResolvers,
+  viewerResolvers,
   scalarTypes,
   notablePersonResolvers,
 );

--- a/src/resolvers/types/user.ts
+++ b/src/resolvers/types/user.ts
@@ -1,0 +1,14 @@
+import { User } from '../../database/entities/user';
+import { SchemaContext } from '../../typings/schemaContext';
+
+export const userResolvers = {
+  User: {
+    async photoUrl(
+      { fbId }: User,
+      _: undefined,
+      { userPhotoUrlLoader }: SchemaContext,
+    ) {
+      return userPhotoUrlLoader.load(fbId);
+    },
+  },
+};

--- a/src/resolvers/types/viewer.ts
+++ b/src/resolvers/types/viewer.ts
@@ -1,0 +1,17 @@
+import { SchemaContext } from '../../typings/schemaContext';
+
+export const viewerResolvers = {
+  Viewer: {
+    async photoUrl(
+      _: undefined,
+      __: object,
+      { viewer, userPhotoUrlLoader }: SchemaContext,
+    ) {
+      if (viewer) {
+        return userPhotoUrlLoader.load(viewer.fbId);
+      }
+
+      return undefined;
+    },
+  },
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,9 +36,9 @@ api.use(
   bodyParser.json(),
   graphqlExpress(async req => {
     const context: SchemaContext = {
-      userPhotoUrlLoader: new DataLoader<string, string>(fbIds => {
+      userPhotoUrlLoader: new DataLoader<string, string>(async fbIds => {
         return Promise.all(
-          fbIds.map(fbId => getPhotoUrlByFbId(fbId, 'normal')),
+          fbIds.map(async fbId => getPhotoUrlByFbId(fbId, 'normal')),
         );
       }),
     };

--- a/src/typings/schemaContext.ts
+++ b/src/typings/schemaContext.ts
@@ -1,5 +1,6 @@
 import { User } from '../database/entities/user';
 import * as DataLoader from 'dataloader';
+
 export type SchemaContext = {
   viewer?: User;
   userPhotoUrlLoader: DataLoader<string, string>;

--- a/src/typings/schemaContext.ts
+++ b/src/typings/schemaContext.ts
@@ -1,5 +1,5 @@
 import { User } from '../database/entities/user';
-import DataLoader from 'dataloader';
+import * as DataLoader from 'dataloader';
 export type SchemaContext = {
   viewer?: User;
   userPhotoUrlLoader: DataLoader<string, string>;

--- a/src/typings/schemaContext.ts
+++ b/src/typings/schemaContext.ts
@@ -1,5 +1,6 @@
 import { User } from '../database/entities/user';
-
+import DataLoader from 'dataloader';
 export type SchemaContext = {
   viewer?: User;
+  userPhotoUrlLoader: DataLoader<string, string>;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,7 +21,7 @@
 
 "@hollowverse/common@https://github.com/hollowverse/common":
   version "1.2.0"
-  resolved "https://github.com/hollowverse/common#6a59bf9b8fbc7593271c3e26f3bcc5a96fa4fbc7"
+  resolved "https://github.com/hollowverse/common#e2f1e0f8228d67aa2500421fc535a6862eeab203"
   dependencies:
     glob "^7.1.2"
     jszip "^3.1.4"
@@ -1201,6 +1201,10 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+dataloader@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.3.0.tgz#6fec5be4b30a712e4afd30b86b4334566b97673b"
 
 date-fns@^1.27.2:
   version "1.28.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,7 +21,7 @@
 
 "@hollowverse/common@https://github.com/hollowverse/common":
   version "1.2.0"
-  resolved "https://github.com/hollowverse/common#e2f1e0f8228d67aa2500421fc535a6862eeab203"
+  resolved "https://github.com/hollowverse/common#04802ad8708c809d62eb524dc9e6e630176e9bbe"
   dependencies:
     glob "^7.1.2"
     jszip "^3.1.4"


### PR DESCRIPTION
This PR implements support for `user.photoUrl` and `viewer.photoUrl` fields. The photos are fetched from the public Facebook API on demand. The URLs are cached for the lifetime of the request using Facebook's [Data Loader](https://github.com/facebook/dataloader) library, so no matter how many times a particular `photoUrl` is repeated in a single query, every requested `photoUrl` will only query the Facebook API once.

Closes hollowverse/design#10