### PR TITLE
Add commentsUrl field on NotablePerson

### DIFF
--- a/firebaseExport.json
+++ b/firebaseExport.json
@@ -69,7 +69,8 @@
       "labels" : [ "Greek Orthodox", "Democrat", "Liberal" ],
       "name" : "Tom Hanks",
       "photoUrl" : "https://firebasestorage.googleapis.com/v0/b/hollowverse-c9cad.appspot.com/o/np_123456_150.png?alt=media&token=082c5d81-faba-4c1a-868b-570b538b6a9a",
-      "summary": "Hanks has run the gamut of Christian denominations from Mormonism to Catholicism but seems to have settled on Greek Orthodox.\nHanks is a hardcore Democrat and liberal, throwing his weight behind gay marriage, alternative energy, environmentalism, and Obama."
+      "summary": "Hanks has run the gamut of Christian denominations from Mormonism to Catholicism but seems to have settled on Greek Orthodox.\nHanks is a hardcore Democrat and liberal, throwing his weight behind gay marriage, alternative energy, environmentalism, and Obama.",
+      "oldSlug": "tom-hanks"
     }
   },
   "slugToID" : {

--- a/schema.graphql
+++ b/schema.graphql
@@ -50,7 +50,7 @@ type NotablePerson {
   #
   # This should be treated as an opaque value because the protocol and path parts
   # of this URL might be different depending on whether the notable person
-  # was imported from the old Hollowverse website or not. The leading slash may
+  # was imported from the old Hollowverse website or not. The trailing slash may
   # also be included or removed.
   #
   # Example: http://hollowverse.com/tom-hanks/ or https://hollowverse.com/Bill_Gates

--- a/schema.graphql
+++ b/schema.graphql
@@ -46,6 +46,15 @@ type NotablePerson {
   events: [NotablePersonEvent!]!
   labels: [Label!]!
   summary: String
+  # This is used to load Facebook comments on the client.
+  #
+  # This should be treated as an opaque value because the protocol and path parts
+  # of this URL might be different depending on whether the notable person
+  # was imported from the old Hollowverse website or not. The leading slash may
+  # also be included or removed.
+  #
+  # Example: http://hollowverse.com/tom-hanks/ or https://hollowverse.com/Bill_Gates
+  commentsUrl: String!
 }
 
 interface UserInterface {

--- a/src/database/entities/notablePerson.ts
+++ b/src/database/entities/notablePerson.ts
@@ -26,6 +26,15 @@ export class NotablePerson extends BaseEntity {
   @Column({ unique: true, nullable: false })
   slug: string;
 
+  /**
+   * The path part of the URL for that notable person on the old Hollowverse
+   * website, without the leading slash.
+   * `null` if this notable person was not imported from the old website.
+   * @example: For, http://hollowverse.com/tom-hanks, this would be `tom-hanks`.
+   */
+  @Column({ type: 'varchar', unique: true, nullable: true })
+  oldSlug: string | null;
+
   @Trim()
   @IsNotEmpty()
   @Column({ type: 'varchar', nullable: false })
@@ -43,6 +52,18 @@ export class NotablePerson extends BaseEntity {
 
   /** Photo URL computed from `photoId`, not an actual column. */
   photoUrl: string;
+
+  /**
+   * This is used to load Facebook comments on the client.
+   * 
+   * This should be treated as an opaque value because the protocol and path parts
+   * of this URL might be different depending on whether the notable person
+   * was imported from the old Hollowverse website or not. The leading slash may
+   * also be included or removed.
+   * 
+   * @example: http://hollowverse.com/tom-hanks/ or https://hollowverse.com/Bill_Gates
+   */
+  commentsUrl: string;
 
   @OneToMany(_ => NotablePersonEvent, event => event.notablePerson, {
     cascadeInsert: true,
@@ -63,5 +84,22 @@ export class NotablePerson extends BaseEntity {
       `notable-people/${this.slug}`,
       'https://files.hollowverse.com',
     ).toString();
+  }
+
+  @AfterLoad()
+  setCommentsUrl() {
+    let url: URL;
+
+    if (this.oldSlug !== null) {
+      url = new URL(
+        `${this.oldSlug}/`,
+        // tslint:disable-next-line:no-http-string
+        'http://hollowverse.com',
+      );
+    } else {
+      url = new URL(`${this.slug}`, 'https://hollowverse.com');
+    }
+
+    this.commentsUrl = url.toString();
   }
 }

--- a/src/database/entities/notablePerson.ts
+++ b/src/database/entities/notablePerson.ts
@@ -30,7 +30,7 @@ export class NotablePerson extends BaseEntity {
    * The path part of the URL for that notable person on the old Hollowverse
    * website, without the leading slash.
    * `null` if this notable person was not imported from the old website.
-   * @example: For, http://hollowverse.com/tom-hanks, this would be `tom-hanks`.
+   * @example: For http://hollowverse.com/tom-hanks, this would be `tom-hanks`.
    */
   @Column({ type: 'varchar', unique: true, nullable: true })
   oldSlug: string | null;
@@ -58,7 +58,7 @@ export class NotablePerson extends BaseEntity {
    * 
    * This should be treated as an opaque value because the protocol and path parts
    * of this URL might be different depending on whether the notable person
-   * was imported from the old Hollowverse website or not. The leading slash may
+   * was imported from the old Hollowverse website or not. The trailing slash may
    * also be included or removed.
    * 
    * @example: http://hollowverse.com/tom-hanks/ or https://hollowverse.com/Bill_Gates

--- a/src/scripts/importFirebaseData.ts
+++ b/src/scripts/importFirebaseData.ts
@@ -17,6 +17,7 @@ type FirebaseExport = {
       summary: string | null;
       labels: string[];
       photoUrl: string;
+      oldSlug: string;
       events: [
         {
           id: number;
@@ -58,13 +59,14 @@ connection
       return Promise.all(
         Object.entries(
           json.notablePersons,
-        ).map(async ([id, { name, labels, events, summary }]) => {
+        ).map(async ([id, { name, labels, events, summary, oldSlug }]) => {
           const notablePerson = new NotablePerson();
           notablePerson.id = uuid();
           notablePerson.name = name;
           notablePerson.slug = findKey(json.slugToID, v => v === id)!;
           notablePerson.photoId = notablePerson.slug;
           notablePerson.summary = summary;
+          notablePerson.oldSlug = oldSlug;
 
           notablePerson.labels = await entityManager.save(
             labels.map(text => {

--- a/src/scripts/insertMockData.ts
+++ b/src/scripts/insertMockData.ts
@@ -37,6 +37,7 @@ if (isUsingProductionDatabase === false) {
             notablePerson.summary = chance.sentence();
             notablePerson.slug = kebabCase(notablePerson.name);
             notablePerson.photoId = chance.apple_token();
+            notablePerson.commentsUrl = chance.url();
             notablePerson.labels = await entityManager.save(
               times(2, () => {
                 const label = new NotablePersonLabel();


### PR DESCRIPTION
This is used to load Facebook comments on the client.

This should be treated as an opaque value because the protocol and path parts of this URL might be different depending on whether the notable person was imported from the old Hollowverse website or not. The trailing slash may also be included or removed.

Example: http://hollowverse.com/tom-hanks/ or https://hollowverse.com/Bill_Gates