### PR TITLE
Use / for health checks

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -58,7 +58,7 @@ api.use(
   }),
 );
 
-api.use('/health', health);
+api.use('/', health);
 
 api.use(
   '/graphql',


### PR DESCRIPTION
It seems that the application load balancer is not respecting the health URL configured in EB settings and instead pinging `/` to check for health status, which returns 404 (the API is at `/graphql`). So this is causing EB to think that the API server is unhealthy.