### PR TITLE
Remove debug header supports

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -93,21 +93,10 @@ api.use(
   }),
 );
 
-const debugHeaders = [
-  process.env.FB_ACCESS_TOKEN
-    ? `'Authorization': 'Bearer ${process.env.FB_ACCESS_TOKEN}'`
-    : null,
-].filter(Boolean);
-
 api.use(
   '/graphiql',
   graphiqlExpress({
     endpointURL: '/graphql',
-    ...process.env.NODE_ENV === 'production'
-      ? undefined
-      : {
-          passHeader: debugHeaders.join('\n'),
-        },
   }),
 );
 


### PR DESCRIPTION
This does not work well, particularly with dockerized development environment because Facebook authentication tokens are short lived and updating the environment variable requires restarting the server or, for Docker Compose, restarting the entire service.

Instead, a dedicated IDE like [GraphQL Playground](https://github.com/graphcool/graphql-playground) should be used to test authenticated requests.

I've already updated the wiki entry on API development.