### PR TITLE
Remove references to firebaseExport.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,5 @@ RUN yarn --prod
 COPY ./dist ./dist/
 
 COPY ./schema.graphql ./
-COPY ./firebaseExport.json ./
 
 CMD yarn start

--- a/deploy.js
+++ b/deploy.js
@@ -45,7 +45,6 @@ async function main() {
         'build.zip',
         [
           'schema.graphql',
-          'firebaseExport.json',
           'dist/**/*',
           'secrets/**/*',
           'yarn.lock',


### PR DESCRIPTION
This is causing deployment to fail because #24 removed this file but not references to it in `Dockerfile` and `deploy.js`