### PR TITLE
Move photoUrl and commentsUrl logic to GraphQL layer

### DIFF
--- a/src/database/entities/notablePerson.ts
+++ b/src/database/entities/notablePerson.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
   Column,
-  AfterLoad,
   PrimaryGeneratedColumn,
   JoinColumn,
   OneToMany,
@@ -15,7 +14,6 @@ import { BaseEntity } from './base';
 import { NotablePersonEvent } from './event';
 import { NotablePersonLabel } from './notablePersonLabel';
 import { EditorialSummary } from './editorialSummary';
-import { URL } from 'url';
 
 /**
  * A public figure or an influential person
@@ -54,20 +52,6 @@ export class NotablePerson extends BaseEntity {
   @Trim()
   photoId: string | null;
 
-  /** Photo URL computed from `photoId`, not an actual column. */
-  photoUrl: string | null;
-
-  /**
-   * This is used to load Facebook comments on the client.
-   * 
-   * This should be treated as an opaque value because the protocol and path parts
-   * of this URL might be different depending on whether the notable person
-   * was imported from the old Hollowverse website or not. The trailing slash may
-   * also be included or removed.
-   * @example: http://hollowverse.com/tom-hanks/ or https://hollowverse.com/Bill_Gates
-   */
-  commentsUrl: string;
-
   @OneToMany(_ => NotablePersonEvent, event => event.notablePerson, {
     cascadeInsert: true,
     cascadeUpdate: true,
@@ -90,31 +74,4 @@ export class NotablePerson extends BaseEntity {
   @ManyToMany(_ => NotablePersonLabel)
   @JoinTable()
   labels: NotablePersonLabel[];
-
-  @AfterLoad()
-  setPhotoUrl() {
-    this.photoUrl = this.photoId
-      ? new URL(
-          `notable-people/${this.photoId}`,
-          'https://files.hollowverse.com',
-        ).toString()
-      : null;
-  }
-
-  @AfterLoad()
-  setCommentsUrl() {
-    let url: URL;
-
-    if (this.oldSlug !== null) {
-      url = new URL(
-        `${this.oldSlug}/`,
-        // tslint:disable-next-line:no-http-string
-        'http://hollowverse.com',
-      );
-    } else {
-      url = new URL(`${this.slug}`, 'https://hollowverse.com');
-    }
-
-    this.commentsUrl = url.toString();
-  }
 }

--- a/src/resolvers/queries/notablePerson.ts
+++ b/src/resolvers/queries/notablePerson.ts
@@ -8,6 +8,7 @@ import {
   EventsNotablePersonArgs,
   NotablePerson as NotablePersonType,
 } from '../../typings/schema';
+import { URL } from 'url';
 
 export const notablePersonResolvers = {
   RootQuery: {
@@ -66,6 +67,31 @@ export const notablePersonResolvers = {
       }
 
       return null;
+    },
+
+    photoUrl(notablePerson: NotablePerson) {
+      return notablePerson.photoId
+        ? new URL(
+            `notable-people/${notablePerson.photoId}`,
+            'https://files.hollowverse.com',
+          ).toString()
+        : null;
+    },
+
+    commentsUrl(notablePerson: NotablePerson) {
+      let url: URL;
+
+      if (notablePerson.oldSlug !== null) {
+        url = new URL(
+          `${notablePerson.oldSlug}/`,
+          // tslint:disable-next-line:no-http-string
+          'http://hollowverse.com',
+        );
+      } else {
+        url = new URL(`${notablePerson.slug}`, 'https://hollowverse.com');
+      }
+
+      return url.toString();
     },
   },
 

--- a/src/resolvers/queries/notablePerson.ts
+++ b/src/resolvers/queries/notablePerson.ts
@@ -69,7 +69,7 @@ export const notablePersonResolvers = {
       return null;
     },
 
-    photoUrl(notablePerson: NotablePerson) {
+    photoUrl(notablePerson: NotablePerson): NotablePersonType['photoUrl'] {
       return notablePerson.photoId
         ? new URL(
             `notable-people/${notablePerson.photoId}`,
@@ -78,7 +78,9 @@ export const notablePersonResolvers = {
         : null;
     },
 
-    commentsUrl(notablePerson: NotablePerson) {
+    commentsUrl(
+      notablePerson: NotablePerson,
+    ): NotablePersonType['commentsUrl'] {
       let url: URL;
 
       if (notablePerson.oldSlug !== null) {

--- a/src/scripts/insertMockData.ts
+++ b/src/scripts/insertMockData.ts
@@ -56,7 +56,6 @@ if (isUsingProductionDatabase === false) {
               null,
               faker.random.uuid(),
             ]);
-            notablePerson.commentsUrl = faker.internet.url();
             notablePerson.labels = take(
               faker.helpers.shuffle(notablePersonLabels),
               Math.min(4, faker.random.number(notablePersonLabels.length)),


### PR DESCRIPTION
This PR moves the logic for setting the `photoUrl` and `commentsUrl` values on `NotablePerson` to GraphQL resolvers. Since it's unlikely we are going to change or introduce another data layer, this is a cleaner way to set these values.