### PR TITLE
Replace class-sanitizer with @hollowverse/class-sanitizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     }
   },
   "dependencies": {
+    "@hollowverse/class-sanitizer": "^0.1.1",
     "@hollowverse/common": "hollowverse/common",
     "apollo-server-express": "^1.1.2",
     "body-parser": "^1.18.2",
-    "class-sanitizer": "^0.0.5",
     "class-validator": "^0.7.2",
     "cors": "^2.8.4",
     "dataloader": "^1.3.0",

--- a/src/database/entities/BaseEntity.ts
+++ b/src/database/entities/BaseEntity.ts
@@ -1,6 +1,6 @@
 import { BeforeInsert, BeforeUpdate } from 'typeorm';
 import { validateOrReject } from 'class-validator';
-import { sanitizeAsync } from 'class-sanitizer';
+import { sanitizeAsync } from '@hollowverse/class-sanitizer';
 
 /**
  * Base entity for the database layer.

--- a/src/database/entities/EditorialSummary.ts
+++ b/src/database/entities/EditorialSummary.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 import { IsNotEmpty, ValidateIf } from 'class-validator';
-import { Trim } from 'class-sanitizer';
+import { Trim } from '@hollowverse/class-sanitizer';
 import { BaseEntity } from './BaseEntity';
 import { EditorialSummaryNode } from './EditorialSummaryNode';
 

--- a/src/database/entities/EventLabel.ts
+++ b/src/database/entities/EventLabel.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
 import { IsNotEmpty } from 'class-validator';
-import { Trim } from 'class-sanitizer';
+import { Trim } from '@hollowverse/class-sanitizer';
 import { BaseEntity } from './BaseEntity';
 
 /**

--- a/src/database/entities/NotablePerson.ts
+++ b/src/database/entities/NotablePerson.ts
@@ -8,7 +8,7 @@ import {
   ManyToMany,
   JoinTable,
 } from 'typeorm';
-import { Trim } from 'class-sanitizer';
+import { Trim } from '@hollowverse/class-sanitizer';
 import { IsNotEmpty, ValidateIf } from 'class-validator';
 import { BaseEntity } from './BaseEntity';
 import { NotablePersonEvent } from './NotablePersonEvent';

--- a/src/database/entities/NotablePersonEvent.ts
+++ b/src/database/entities/NotablePersonEvent.ts
@@ -8,7 +8,7 @@ import {
   JoinTable,
 } from 'typeorm';
 import { IsUrl, IsNotEmpty, ValidateIf } from 'class-validator';
-import { Trim } from 'class-sanitizer';
+import { Trim } from '@hollowverse/class-sanitizer';
 import { BaseEntity } from './BaseEntity';
 import { NotablePerson } from './NotablePerson';
 import { User } from './User';

--- a/src/database/entities/NotablePersonEventComment.ts
+++ b/src/database/entities/NotablePersonEventComment.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
 import { IsNotEmpty } from 'class-validator';
-import { Trim } from 'class-sanitizer';
+import { Trim } from '@hollowverse/class-sanitizer';
 import { BaseEntity } from './BaseEntity';
 import { NotablePersonEvent } from './NotablePersonEvent';
 import { User } from './User';

--- a/src/database/entities/NotablePersonLabel.ts
+++ b/src/database/entities/NotablePersonLabel.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
 import { IsNotEmpty } from 'class-validator';
-import { Trim } from 'class-sanitizer';
+import { Trim } from '@hollowverse/class-sanitizer';
 import { BaseEntity } from './BaseEntity';
 
 /**

--- a/src/database/entities/User.ts
+++ b/src/database/entities/User.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 import { IsEmail, IsNotEmpty, ValidateIf } from 'class-validator';
-import { Trim } from 'class-sanitizer';
+import { Trim } from '@hollowverse/class-sanitizer';
 import { normalizeEmail, isEmail } from 'validator';
 import { BaseEntity } from './BaseEntity';
 import { NotablePersonEvent } from './NotablePersonEvent';

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,6 +72,12 @@
     glob "^7.1.2"
     graphql-tools "^1.1.0"
 
+"@hollowverse/class-sanitizer@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@hollowverse/class-sanitizer/-/class-sanitizer-0.1.1.tgz#44f948a5640941103e22af877ea056f707af77d8"
+  dependencies:
+    validator "^9.2.0"
+
 "@hollowverse/common@hollowverse/common":
   version "2.1.0"
   resolved "https://codeload.github.com/hollowverse/common/tar.gz/9fe515915557cbc8c42bfe363254a1ae6cb922d1"
@@ -839,12 +845,6 @@ ci-info@^1.0.0:
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
-
-class-sanitizer@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/class-sanitizer/-/class-sanitizer-0.0.5.tgz#1a0b357730328e0123cb6fea1cb2530aa3854c58"
-  dependencies:
-    validator "^5.1.0"
 
 class-validator@^0.7.2:
   version "0.7.2"
@@ -5076,10 +5076,6 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-validator@^5.1.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-5.7.0.tgz#7a87a58146b695ac486071141c0c49d67da05e5c"
-
 validator@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-7.2.0.tgz#a63dcbaba51d4350bf8df20988e0d5a54d711791"
@@ -5087,6 +5083,10 @@ validator@^7.0.0:
 validator@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-9.0.0.tgz#6c1ef955e007af704adea86ae8a76da84a6c172e"
+
+validator@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-9.2.0.tgz#ad216eed5f37cac31a6fe00ceab1f6b88bded03e"
 
 vary@^1, vary@~1.1.1:
   version "1.1.2"


### PR DESCRIPTION
This allows us to fix an issue where `EditorialSummaryNode.text` is being trimmed when the node is inserted.

More details: https://github.com/typestack/class-sanitizer/issues/8