### PR TITLE
Revert to older TypeORM version

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "node-vibrant": "^3.0.0",
     "npm-run-all": "^4.0.2",
     "reflect-metadata": "^0.1.10",
-    "typeorm": "^0.2.0-alpha.15",
+    "typeorm": "^0.1.12",
     "validator": "^9.0.0"
   },
   "devDependencies": {

--- a/src/database/entities/EditorialSummary.ts
+++ b/src/database/entities/EditorialSummary.ts
@@ -26,7 +26,8 @@ export class EditorialSummary extends BaseEntity {
    */
 
   @OneToMany(_ => EditorialSummaryNode, node => node.editorialSummary, {
-    cascade: ['insert', 'update'],
+    cascadeInsert: true,
+    cascadeUpdate: true,
     eager: false,
   })
   nodes: EditorialSummaryNode[];

--- a/src/database/entities/NotablePerson.ts
+++ b/src/database/entities/NotablePerson.ts
@@ -68,7 +68,8 @@ export class NotablePerson extends BaseEntity {
   photos: Photo[];
 
   @OneToMany(_ => NotablePersonEvent, event => event.notablePerson, {
-    cascade: ['insert', 'update'],
+    cascadeInsert: true,
+    cascadeUpdate: true,
   })
   events: NotablePersonEvent[];
 
@@ -77,7 +78,7 @@ export class NotablePerson extends BaseEntity {
    * which is the content from the old Hollowverse
    */
   @OneToOne(_ => EditorialSummary, {
-    cascade: ['insert'],
+    cascadeInsert: true,
     nullable: true,
     lazy: true,
   })

--- a/src/database/entities/NotablePersonEvent.ts
+++ b/src/database/entities/NotablePersonEvent.ts
@@ -86,7 +86,8 @@ export class NotablePersonEvent extends BaseEntity {
    * @deprecated
    */
   @OneToMany(_ => NotablePersonEventComment, comment => comment.event, {
-    cascade: ['insert', 'update'],
+    cascadeInsert: true,
+    cascadeUpdate: true,
   })
   comments: NotablePersonEventComment[];
 

--- a/src/database/entities/Photo.ts
+++ b/src/database/entities/Photo.ts
@@ -52,7 +52,7 @@ export class Photo extends BaseEntity {
 
   @OneToOne(_ => ColorPalette, {
     nullable: true,
-    cascade: ['insert', 'update', 'remove'],
+    cascadeAll: true,
     lazy: true,
   })
   @JoinColumn()

--- a/src/database/entities/User.ts
+++ b/src/database/entities/User.ts
@@ -30,12 +30,14 @@ export class User extends BaseEntity {
   photoId: string | null;
 
   @OneToMany(_ => NotablePersonEvent, event => event.owner, {
-    cascade: ['insert', 'update'],
+    cascadeInsert: true,
+    cascadeUpdate: true,
   })
   events: NotablePersonEvent[];
 
   @OneToMany(_ => NotablePersonEventComment, comment => comment.owner, {
-    cascade: ['insert', 'update'],
+    cascadeInsert: true,
+    cascadeUpdate: true,
   })
   comments: NotablePersonEventComment[];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,7 +902,7 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-highlight@^1.2.2:
+cli-highlight@^1.1.4:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-1.2.3.tgz#b200f97ed0e43d24633e89de0f489a48bb87d2bf"
   dependencies:
@@ -5150,13 +5150,13 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typeorm@^0.2.0-alpha.15:
-  version "0.2.0-alpha.15"
-  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.2.0-alpha.15.tgz#ff2a2d2c5afbcc66968fe9351bf99d05be974c22"
+typeorm@^0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.1.12.tgz#adcd45f302d21ab4d5b02671bfa8c07cea044af7"
   dependencies:
     app-root-path "^2.0.1"
     chalk "^2.0.1"
-    cli-highlight "^1.2.2"
+    cli-highlight "^1.1.4"
     debug "^3.1.0"
     dotenv "^4.0.0"
     glob "^7.1.2"


### PR DESCRIPTION
I had to upgrade TypeORM to an alpha version because it had the necessary fixes to run the migrations and populate the database color palettes table. Unfortunately, it looks like that version was causing increased CPU load and brought the API down. I deployed an older version of the API manually.