### PR TITLE
Treat user errors as data, refactor error handling

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -206,6 +206,22 @@ type RootQuery {
   notablePeople(first: Int!, after: ID): NotablePersonConnection!
 }
 
+enum UserErrorType {
+  # Thrown when an operation requires that the request is authentiacted
+  AUTHENTICATION_REQUIRED
+
+  OPERATION_NOT_ALLOWED
+
+  # Thrown when an access token is empty, invalid or expired
+  INVALID_ACCESS_TOKEN
+}
+
+type UserError {
+  type: UserErrorType
+  message: String
+  field: String
+}
+
 input CreateUserInput {
   # A valid Facebook access token issued for the Hollowverse application on Facebook
   fbAccessToken: String!
@@ -225,7 +241,15 @@ input CreateNotablePersonInput {
 }
 
 type CreateNotablePersonPayload {
-  name: String!
+  notablePerson: NotablePerson
+  wasSuccessful: Boolean!
+  userErrors: [UserError!]!
+}
+
+type CreateUserPayload {
+  user: Viewer
+  wasSuccessful: Boolean!
+  userErrors: [UserError!]!
 }
 
 type RootMutation {
@@ -233,7 +257,7 @@ type RootMutation {
   # issued for the Hollowverse application.
   # The name of the new user will be obtained from Facebook if
   # not specified in the mutation input.
-  createUser(input: CreateUserInput!): Viewer
+  createUser(input: CreateUserInput!): CreateUserPayload
 
   # Create a new entry for a notable person
   createNotablePerson(
@@ -244,14 +268,4 @@ type RootMutation {
 schema {
   query: RootQuery
   mutation: RootMutation
-}
-
-enum ApiErrorType {
-  # Thrown when an operation requires that the request is authorized
-  MustBeAuthorizedError
-
-  OperationNotAllowedError
-
-  # Thrown when an access token is empty, invalid or expired
-  InvalidAccessTokenError
 }

--- a/src/examples/createUser.graphql
+++ b/src/examples/createUser.graphql
@@ -1,6 +1,13 @@
 mutation CreateUser {
   createUser(input: { fbAccessToken: "fb_access_token" }) {
-    name
-    id
+    user {
+      name
+      id
+    }
+    wasSuccessful
+    userErrors {
+      field
+      message
+    }
   }
 }

--- a/src/helpers/apiError.ts
+++ b/src/helpers/apiError.ts
@@ -1,37 +1,37 @@
-const messagesByErrorType = {
-  OperationNotAllowedError: 'This operation is not allowed',
-  MustBeAuthorizedError:
+import { UserErrorType } from '../typings/schema';
+
+const messagesByErrorType: Record<UserErrorType, string> = {
+  OPERATION_NOT_ALLOWED: 'This operation is not allowed',
+  AUTHENTICATION_REQUIRED:
     'This operation requires that the request is authenticated',
-  InvalidAccessTokenError:
+  INVALID_ACCESS_TOKEN:
     'The passed access token is either empty, expired or invalid',
 };
 
-type ApiErrorType = keyof typeof messagesByErrorType;
-
-type ApiErrorOptions = {
+type UserErrorOptions = {
   isSensitive: boolean;
 };
 
-const defaultOptions: ApiErrorOptions = {
+const defaultOptions: UserErrorOptions = {
   isSensitive: true,
 };
 
 /**
- * Custom API error class, requires a pre-defined
+ * Custom error class, requires a pre-defined
  * error type and handles removing potentially sensitive properties.
  */
-export class ApiError extends Error {
+export class UserError extends Error {
   /**
-   * @param type One of the pre-defined API error types.
+   * @param type One of the pre-defined user error types.
    * @param message If not defined, the default error message for the specified
    * error type is used.
    * @param options When `options.isSensitive` is set to `true`,
    * it makes sure to remove sensitive props from the error object.
    */
   constructor(
-    type: ApiErrorType,
+    type: UserErrorType,
     message: string = messagesByErrorType[type],
-    options: ApiErrorOptions = defaultOptions,
+    options: UserErrorOptions = defaultOptions,
   ) {
     super();
     this.name = type;

--- a/src/helpers/facebook.ts
+++ b/src/helpers/facebook.ts
@@ -1,6 +1,6 @@
 import * as got from 'got';
 import { readJson } from './readFile';
-import { ApiError } from './apiError';
+import { UserError } from './apiError';
 
 const facebookAppConfig = readJson<FacebookAppConfig>(
   'secrets/facebookApp.json',
@@ -19,7 +19,7 @@ const facebookAppConfig = readJson<FacebookAppConfig>(
  */
 async function verifyFacebookAccessToken(token: string) {
   if (!token) {
-    throw new ApiError('InvalidAccessTokenError');
+    throw new UserError('INVALID_ACCESS_TOKEN');
   }
 
   const app = await facebookAppConfig;
@@ -39,7 +39,7 @@ async function verifyFacebookAccessToken(token: string) {
     }
   }
 
-  throw new ApiError('InvalidAccessTokenError');
+  throw new UserError('INVALID_ACCESS_TOKEN');
 }
 
 /**

--- a/src/helpers/formatError.ts
+++ b/src/helpers/formatError.ts
@@ -1,7 +1,7 @@
 import { GraphQLError } from 'graphql/error';
 import { ValidationError } from 'class-validator';
 import { QueryFailedError } from 'typeorm';
-import { ApiError } from './apiError';
+import { UserError } from './apiError';
 
 /**
  * Picks properties of error objects that are assumed to not contain
@@ -14,7 +14,7 @@ function pickSafeProps(error: Error | ValidationError | QueryFailedError) {
     const { property, constraints } = error;
 
     return { property, constraints };
-  } else if (error instanceof ApiError) {
+  } else if (error instanceof UserError) {
     // `ApiError` knows how to remove unsafe props. Just return it as-is.
     return error;
   } else {

--- a/src/helpers/requireAuthentication.ts
+++ b/src/helpers/requireAuthentication.ts
@@ -1,5 +1,5 @@
 import { SchemaContext } from '../typings/schemaContext';
-import { ApiError } from './apiError';
+import { UserError } from './apiError';
 import { GraphQLResolveInfo } from 'graphql/type';
 import { FnResolver } from '../typings/resolverMap';
 
@@ -21,7 +21,7 @@ export function requireAuthentication<S, A, T>(
     if (context.viewer) {
       return resolver(source, args, context, info);
     } else {
-      throw new ApiError('MustBeAuthorizedError');
+      throw new UserError('AUTHENTICATION_REQUIRED');
     }
   };
 }

--- a/src/resolvers/mutations/createNotablePerson.ts
+++ b/src/resolvers/mutations/createNotablePerson.ts
@@ -17,7 +17,11 @@ export const resolvers: Partial<ResolverMap> = {
 
         await notablePeople.save(notablePerson);
 
-        return { name };
+        return {
+          notablePerson,
+          wasSuccessful: true,
+          userErrors: [],
+        };
       },
     ),
   },

--- a/src/resolvers/mutations/createUser.ts
+++ b/src/resolvers/mutations/createUser.ts
@@ -1,7 +1,7 @@
 import { connection } from '../../database/connection';
 import { User } from '../../database/entities/User';
 import { sendFacebookAuthenticatedRequest } from '../../helpers/facebook';
-import { ApiError } from '../../helpers/apiError';
+import { UserError } from '../../helpers/apiError';
 
 import { ResolverMap } from '../../typings/resolverMap';
 
@@ -16,8 +16,8 @@ export const resolvers: Partial<ResolverMap> = {
      */
     async createUser(_, { input: { fbAccessToken, email, name } }, context) {
       if (context.viewer) {
-        throw new ApiError(
-          'OperationNotAllowedError',
+        throw new UserError(
+          'OPERATION_NOT_ALLOWED',
           'Cannot create a new user because the request is already authenticated',
         );
       }
@@ -57,7 +57,13 @@ export const resolvers: Partial<ResolverMap> = {
 
       const users = db.getRepository(User);
 
-      return users.save(user);
+      await users.save(user);
+
+      return {
+        user,
+        wasSuccessful: true,
+        userErrors: [],
+      };
     },
   },
 };


### PR DESCRIPTION
(inspired by this article: [What went wrong? Best Practices for Surfacing Error Messages in a GraphQL API](https://about.sourcegraph.com/graphql/what-went-wrong-best-practices-for-surfacing-error-messages-in-a-graphql-api/))