### PR TITLE
Update photo URLs to new S3 bucket

### DIFF
--- a/src/dataLoaders/photoUrl.ts
+++ b/src/dataLoaders/photoUrl.ts
@@ -16,7 +16,7 @@ export const photoUrlLoader = new DataLoader<string | undefined, string>(
           const photo = await photos.findOne({ id });
           if (photo) {
             return String(
-              new URL(photo.s3Path, 'https://files.hollowverse.com'),
+              new URL(photo.s3Path, 'https://photos.hollowverse.com'),
             );
           }
         }

--- a/src/resolvers/queries/notablePerson.ts
+++ b/src/resolvers/queries/notablePerson.ts
@@ -112,7 +112,7 @@ export const resolvers: Partial<ResolverMap> = {
           if (photoId) {
             return new URL(
               `notable-people/${photoId}`,
-              'https://files.hollowverse.com',
+              'https://photos.hollowverse.com',
             ).toString();
           }
         }


### PR DESCRIPTION
The new `photos.hollowverse.com` sub-domain is backed by a CloudFront distribution for a new S3 bucket that is managed by `hollowverse/process-image`. :tada: 