### PR TITLE
Revert "Update photo URLs to new S3 bucket"

### DIFF
--- a/src/dataLoaders/photoUrl.ts
+++ b/src/dataLoaders/photoUrl.ts
@@ -16,7 +16,7 @@ export const photoUrlLoader = new DataLoader<string | undefined, string>(
           const photo = await photos.findOne({ id });
           if (photo) {
             return String(
-              new URL(photo.s3Path, 'https://photos.hollowverse.com'),
+              new URL(photo.s3Path, 'https://files.hollowverse.com'),
             );
           }
         }

--- a/src/resolvers/queries/notablePerson.ts
+++ b/src/resolvers/queries/notablePerson.ts
@@ -112,7 +112,7 @@ export const resolvers: Partial<ResolverMap> = {
           if (photoId) {
             return new URL(
               `notable-people/${photoId}`,
-              'https://photos.hollowverse.com',
+              'https://files.hollowverse.com',
             ).toString();
           }
         }


### PR DESCRIPTION
Reverts hollowverse/api#64

Some photos for NPs whose names contain parenthesis are failing to load with 403 status. I think it has to do with URL decoding. I'm reverting the changes while investigating the issue. We'll also need to update Algolia's indexes with the new photo URLs after we fix this issue.