### PR TITLE
Update photo URLs to new S3 bucket again

### DIFF
--- a/src/dataLoaders/photoUrl.ts
+++ b/src/dataLoaders/photoUrl.ts
@@ -16,7 +16,7 @@ export const photoUrlLoader = new DataLoader<string | undefined, string>(
           const photo = await photos.findOne({ id });
           if (photo) {
             return String(
-              new URL(photo.s3Path, 'https://files.hollowverse.com'),
+              new URL(photo.s3Path, 'https://photos.hollowverse.com'),
             );
           }
         }

--- a/src/resolvers/queries/notablePerson.ts
+++ b/src/resolvers/queries/notablePerson.ts
@@ -112,7 +112,7 @@ export const resolvers: Partial<ResolverMap> = {
           if (photoId) {
             return new URL(
               `notable-people/${photoId}`,
-              'https://files.hollowverse.com',
+              'https://photos.hollowverse.com',
             ).toString();
           }
         }


### PR DESCRIPTION
This issue with undecoded URIs is now fixed with hollowverse/process-image#5. I'm going to update Algolia's index before merging this.

Reverts hollowverse/api#65