### PR TITLE
Remove migrations in connection for now

### DIFF
--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -24,7 +24,4 @@ export const connectionPromise = createConnection({
   port: Number(TYPEORM_PORT),
   username: TYPEORM_USERNAME,
   password: TYPEORM_PASSWORD,
-  migrations: isProd
-    ? ['dist/database/migrations/*.js']
-    : ['src/database/migrations/*.ts'],
 });


### PR DESCRIPTION
Because Webpack compiles our code to a single file, specifying paths to migration files won't work. Next time we need to migrate the database schema, we could register the migration classes manually.