### PR TITLE
Remove @requireAuth directive from viewer query

### DIFF
--- a/src/__tests__/createAndQueryUser.ts
+++ b/src/__tests__/createAndQueryUser.ts
@@ -35,14 +35,12 @@ describe('create and query new user', () => {
     }
   });
 
-  it('`viewer` inaccessible for unauthenticated users', async () => {
+  it('`viewer` is `null` for unauthenticated users', async () => {
     expect.hasAssertions();
 
-    try {
-      await context.client.request(viewerQuery);
-    } catch (error) {
-      expect(error.message).toMatch(/auth/i);
-    }
+    const result = (await context.client.request(viewerQuery)) as any;
+
+    expect(result.viewer).toBeNull();
   });
 
   it('visitors can create a new user', async () => {
@@ -98,10 +96,8 @@ describe('create and query new user', () => {
 
     context.client.setHeader('Authorization', 'Bearer 000000');
 
-    try {
-      await context.client.request(viewerQuery);
-    } catch (error) {
-      expect(error.message).toMatch(/auth/i);
-    }
+    const result = (await context.client.request(viewerQuery)) as any;
+
+    expect(result.viewer).toBeNull();
   });
 });

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -212,7 +212,7 @@ type NotablePersonConnection {
 
 type RootQuery {
   # The authenticated user performing the request
-  viewer: Viewer @requireAuth
+  viewer: Viewer
 
   notablePerson(slug: String!): NotablePerson
 


### PR DESCRIPTION
This makes it easier to handle viewer queries on the client-side because we won't have to catch query errors and check for `MustBeAuthroizedError`s. It also does not make much sense to `requireAuth` on the query that's supposed to be used for checking if the user is authenticated :smile:.