### PR TITLE
Add notablePeopleEvents query, use uppercase for most enum types

### DIFF
--- a/src/__tests__/submitNotablePersonEvent.ts
+++ b/src/__tests__/submitNotablePersonEvent.ts
@@ -118,7 +118,7 @@ describe('submit a notable person event', () => {
     expect(result).toEqual({
       submitNotablePersonEvent: {
         result: {
-          state: 'success',
+          state: 'SUCCESS',
         },
       },
     });

--- a/src/authProvider/facebookAuthProvider.ts
+++ b/src/authProvider/facebookAuthProvider.ts
@@ -43,7 +43,7 @@ export class FacebookAuthProvider implements AuthProvider<FacebookAppConfig> {
   private verifyFacebookAccessToken = pMemoize(
     async (token: string) => {
       if (!token) {
-        throw new ApiError('InvalidAccessTokenError');
+        throw new ApiError('INVALID_ACCESS_TOKEN');
       }
 
       const response = await got('https://graph.facebook.com/debug_token', {
@@ -61,7 +61,7 @@ export class FacebookAuthProvider implements AuthProvider<FacebookAppConfig> {
         }
       }
 
-      throw new ApiError('InvalidAccessTokenError');
+      throw new ApiError('INVALID_ACCESS_TOKEN');
     },
     { maxAge: moment.duration(2, 'h').asMilliseconds() },
   );
@@ -148,7 +148,7 @@ export class FacebookAuthProvider implements AuthProvider<FacebookAppConfig> {
             : options.query,
       });
     } catch {
-      throw new ApiError('InternalError');
+      throw new ApiError('INTERNAL');
     }
   }
 }

--- a/src/database/entities/NotablePersonEvent.ts
+++ b/src/database/entities/NotablePersonEvent.ts
@@ -14,7 +14,10 @@ import { NotablePerson } from './NotablePerson';
 import { User } from './User';
 import { NotablePersonEventComment } from './NotablePersonEventComment';
 import { EventLabel } from './EventLabel';
-import { NotablePersonEventType } from '../../typings/schema';
+import {
+  NotablePersonEventType,
+  NotablePersonEventReviewStatus,
+} from '../../typings/schema';
 import { urlValidationOptions } from '../../helpers/validation';
 import { transformTinyIntOrNull } from '../valueTransfomers/tinyIntOrNull';
 
@@ -22,6 +25,11 @@ const eventTypes: Record<NotablePersonEventType, string> = {
   quote: '',
   donation: '',
   appearance: '',
+};
+
+const reviewStatuses: Record<NotablePersonEventReviewStatus, string> = {
+  APPROVED: '',
+  DISAPPROVED: '',
 };
 
 export type EventType = keyof typeof eventTypes;
@@ -52,6 +60,14 @@ export class NotablePersonEvent extends BaseEntity {
     enum: Object.keys(eventTypes),
   })
   type: EventType;
+
+  @Column({
+    nullable: false,
+    type: 'enum',
+    default: null,
+    enum: Object.keys(reviewStatuses),
+  })
+  reviewStatus: NotablePersonEventReviewStatus;
 
   @IsUrl(urlValidationOptions)
   @Trim()

--- a/src/helpers/apiError.ts
+++ b/src/helpers/apiError.ts
@@ -1,15 +1,18 @@
-const messagesByErrorType = {
-  OperationNotAllowedError: 'This operation is not allowed',
-  MustBeAuthorizedError:
-    'This operation requires that the request is authenticated',
-  InvalidAccessTokenError:
-    'The passed access token is either empty, expired or invalid',
-  RoleMismatchError:
-    'The requested operation can only be performed by user with specific roles',
-  InternalError: 'An internal API error has occurred',
-};
+import { ApiErrorType } from '../typings/schema';
+import { oneLine } from 'common-tags';
 
-type ApiErrorType = keyof typeof messagesByErrorType;
+const messagesByErrorType: Record<ApiErrorType, string> = {
+  OPERATION_NOT_ALLOWED: 'This operation is not allowed',
+  NOT_AUTHENTICATED:
+    'This operation requires that the request is authenticated',
+  NOT_AUTHORIZED:
+    'This operation can only be performed by users with specific roles',
+  INVALID_ACCESS_TOKEN:
+    'The passed access token is either empty, expired or invalid',
+  ROLE_MISMATCH: oneLine`The requested operation can only be performed by users with specific roles,
+    but was made by a user with a different role`,
+  INTERNAL: 'An internal API error has occurred',
+};
 
 type ApiErrorOptions = {
   isSensitive: boolean;

--- a/src/helpers/makeResult.ts
+++ b/src/helpers/makeResult.ts
@@ -5,13 +5,13 @@ export function makeErrorResult(
   errorMessage: string,
 ): ErrorResult {
   return {
-    state: 'error',
+    state: 'ERROR',
     errors: [{ code: errorCode, message: errorMessage }],
   };
 }
 
 export function makeSuccessResult(): Result {
   return {
-    state: 'success',
+    state: 'SUCCESS',
   };
 }

--- a/src/resolvers/directives/requireAuth.ts
+++ b/src/resolvers/directives/requireAuth.ts
@@ -7,6 +7,6 @@ export const resolvers: Pick<DirectiveResolverMap, 'requireAuth'> = {
       return next();
     }
 
-    throw new ApiError('MustBeAuthorizedError');
+    throw new ApiError('NOT_AUTHENTICATED');
   },
 };

--- a/src/resolvers/directives/requireOneOfRoles.ts
+++ b/src/resolvers/directives/requireOneOfRoles.ts
@@ -5,7 +5,11 @@ import { ApiError } from '../../helpers/apiError';
 export const resolvers: Pick<DirectiveResolverMap, 'requireOneOfRoles'> = {
   async requireOneOfRoles(next, _source, { roles }, { viewer }) {
     if (!viewer) {
-      throw new ApiError('MustBeAuthorizedError');
+      throw new ApiError('NOT_AUTHENTICATED');
+    }
+
+    if (viewer.role === null) {
+      throw new ApiError('NOT_AUTHORIZED');
     }
 
     if (viewer.role && roles.includes(viewer.role)) {
@@ -24,6 +28,6 @@ export const resolvers: Pick<DirectiveResolverMap, 'requireOneOfRoles'> = {
       `;
     }
 
-    throw new ApiError('RoleMismatchError', errorMessage);
+    throw new ApiError('ROLE_MISMATCH', errorMessage);
   },
 };

--- a/src/resolvers/interfaces/result.ts
+++ b/src/resolvers/interfaces/result.ts
@@ -5,7 +5,7 @@ export const resolvers: Pick<InterfaceResolverMap, 'Result'> = {
   Result: {
     /* tslint:disable-next-line function-name */
     __resolveType(obj: Result) {
-      if (obj.state === 'error') {
+      if (obj.state === 'ERROR') {
         return 'ErrorResult';
       }
 

--- a/src/resolvers/mutations/createUser.ts
+++ b/src/resolvers/mutations/createUser.ts
@@ -19,7 +19,7 @@ export const resolvers: Partial<ResolverMap> = {
     ) {
       if (viewer) {
         throw new ApiError(
-          'OperationNotAllowedError',
+          'OPERATION_NOT_ALLOWED',
           'Cannot create a new user because the request is already authenticated',
         );
       }

--- a/src/resolvers/queries/notablePeopleEvents.ts
+++ b/src/resolvers/queries/notablePeopleEvents.ts
@@ -1,33 +1,15 @@
-import { FindManyOptions } from 'typeorm';
 import { NotablePersonEvent } from '../../database/entities/NotablePersonEvent';
+import { NotablePersonEventType as NodeType } from '../../typings/schema';
 import { ResolverMap } from '../../typings/resolverMap';
+import { createConnectionResolverFromEntity } from '../../helpers/createConnectionResolverFromEntity';
 
 export const resolvers: Partial<ResolverMap> = {
   RootQuery: {
-    async notablePeopleEvents(_, { after, first }, { connection }) {
-      const skip = (Number(after) || 0) + 1;
-      const query: FindManyOptions<NotablePersonEvent> = {
-        order: {
-          postedAt: 'DESC',
-        },
-      };
-      const notablePeopleEvents = connection.getRepository(NotablePersonEvent);
-
-      const [events, all] = await notablePeopleEvents.findAndCount({
-        ...query,
-        take: first,
-        skip,
-      });
-
-      return {
-        edges: events.map((person, i) => ({
-          node: person,
-          cursor: i + skip,
-        })),
-        pageInfo: {
-          hasNextPage: skip + events.length < all,
-        },
-      };
-    },
+    notablePeopleEvents: createConnectionResolverFromEntity<
+      typeof NotablePersonEvent,
+      NodeType
+    >(NotablePersonEvent, {
+      postedAt: 'DESC',
+    }) as any,
   },
 };

--- a/src/resolvers/queries/notablePeopleEvents.ts
+++ b/src/resolvers/queries/notablePeopleEvents.ts
@@ -1,0 +1,33 @@
+import { FindManyOptions } from 'typeorm';
+import { NotablePersonEvent } from '../../database/entities/NotablePersonEvent';
+import { ResolverMap } from '../../typings/resolverMap';
+
+export const resolvers: Partial<ResolverMap> = {
+  RootQuery: {
+    async notablePeopleEvents(_, { after, first }, { connection }) {
+      const skip = (Number(after) || 0) + 1;
+      const query: FindManyOptions<NotablePersonEvent> = {
+        order: {
+          postedAt: 'DESC',
+        },
+      };
+      const notablePeopleEvents = connection.getRepository(NotablePersonEvent);
+
+      const [events, all] = await notablePeopleEvents.findAndCount({
+        ...query,
+        take: first,
+        skip,
+      });
+
+      return {
+        edges: events.map((person, i) => ({
+          node: person,
+          cursor: i + skip,
+        })),
+        pageInfo: {
+          hasNextPage: skip + events.length < all,
+        },
+      };
+    },
+  },
+};

--- a/src/resolvers/resolvers.ts
+++ b/src/resolvers/resolvers.ts
@@ -9,6 +9,7 @@ import { resolvers as resultResolvers } from './interfaces/result';
 
 import { resolvers as notablePersonResolvers } from './queries/notablePerson';
 import { resolvers as notablePeopleResolvers } from './queries/notablePeople';
+import { resolvers as notablePeopleEventsResolvers } from './queries/notablePeopleEvents';
 import { resolvers as createNotablePersonResolvers } from './mutations/createNotablePerson';
 import { resolvers as createUserResolvers } from './mutations/createUser';
 import { resolvers as changeUserIsBannedStatusResolvers } from './mutations/changeUserIsBannedStatus';
@@ -47,6 +48,7 @@ export const resolvers = merge(
   viewerResolvers,
   notablePersonResolvers,
   notablePeopleResolvers,
+  notablePeopleEventsResolvers,
   userResolvers,
   usersResolvers,
   viewerResolvers,

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -334,8 +334,8 @@ type Error {
 }
 
 enum ResultType {
-  success
-  error
+  SUCCESS
+  ERROR
 }
 
 interface Result {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -239,6 +239,11 @@ type NotablePersonEventConnection {
   pageInfo: PageInfo!
 }
 
+input NotablePersonEventsQueryWhereInput {
+  # If specified, quotes will be filtered based on whether they are approved or not
+  isApproved: Boolean
+}
+
 type RootQuery {
   # The authenticated user performing the request
   viewer: Viewer
@@ -251,7 +256,11 @@ type RootQuery {
   users(first: Int!, after: ID, where: UsersQueryWhereInput): UserConnection!
     @requireOneOfRoles(roles: [MODERATOR])
 
-  notablePeopleEvents(first: Int!, after: ID): NotablePersonEventConnection!
+  notablePeopleEvents(
+    first: Int!
+    after: ID
+    where: NotablePersonEventsQueryWhereInput
+  ): NotablePersonEventConnection!
 }
 
 input CreateUserInput {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -395,18 +395,23 @@ schema {
 }
 
 enum ApiErrorType {
-  # Thrown when an operation requires that the request is authorized
-  MustBeAuthorizedError
+  # Thrown when an operation requires that the request is authenticated but
+  # does not have any authentication details
+  NOT_AUTHENTICATED
 
-  OperationNotAllowedError
+  # Thrown when an operation requires special access permissions
+  # but was not issued by a user with an authorized role
+  NOT_AUTHORIZED
+
+  OPERATION_NOT_ALLOWED
 
   # Thrown when an access token is empty, invalid or expired
-  InvalidAccessTokenError
+  INVALID_ACCESS_TOKEN
 
   # Thrown when the user does not have any of the roles required to perform
   # an operation
-  RoleMismatchError
+  ROLE_MISMATCH
 
   # Thrown when an unexpected server error occurs
-  InternalError
+  INTERNAL
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -54,6 +54,11 @@ enum NotablePersonEventType {
   appearance
 }
 
+enum NotablePersonEventReviewStatus {
+  APPROVED
+  DISAPPROVED
+}
+
 enum EditorialSummaryNodeType {
   quote
   heading
@@ -97,6 +102,10 @@ type NotablePersonEvent {
     @deprecated(
       reason: "We decided to remove events on comments in favor of Facebook comments. See https://github.com/hollowverse/hollowverse/issues/207 for discussion."
     )
+
+  # Whether this event was reviewed by a moderator on Hollowverse and approved
+  # or disapproved. `null` if not reviewed.
+  reviewStatus: NotablePersonEventReviewStatus
 }
 
 type EditorialSummary {
@@ -240,8 +249,8 @@ type NotablePersonEventConnection {
 }
 
 input NotablePersonEventsQueryWhereInput {
-  # If specified, quotes will be filtered based on whether they are approved or not
-  isApproved: Boolean
+  # If specified, quotes will be filtered based on whether they are approved, disapproved, or not reviewd at all
+  reviewStatus: NotablePersonEventReviewStatus
 }
 
 type RootQuery {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -230,7 +230,7 @@ type UserConnection {
 }
 
 input UsersQueryWhereInput {
-  # If specified, users will be filtered based on whether ther are banned or not
+  # If specified, users will be filtered based on whether they are banned or not
   isBanned: Boolean
 }
 

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -209,6 +209,11 @@ type NotablePersonEdge {
   node: NotablePerson!
 }
 
+type NotablePersonEventEdge {
+  cursor: ID!
+  node: NotablePersonEvent!
+}
+
 type NotablePersonConnection {
   edges: [NotablePersonEdge!]!
   pageInfo: PageInfo!
@@ -229,6 +234,11 @@ input UsersQueryWhereInput {
   isBanned: Boolean
 }
 
+type NotablePersonEventConnection {
+  edges: [NotablePersonEventEdge!]!
+  pageInfo: PageInfo!
+}
+
 type RootQuery {
   # The authenticated user performing the request
   viewer: Viewer
@@ -240,6 +250,8 @@ type RootQuery {
 
   users(first: Int!, after: ID, where: UsersQueryWhereInput): UserConnection!
     @requireOneOfRoles(roles: [MODERATOR])
+
+  notablePeopleEvents(first: Int!, after: ID): NotablePersonEventConnection!
 }
 
 input CreateUserInput {

--- a/tslint.json
+++ b/tslint.json
@@ -2,6 +2,7 @@
   "extends": ["./node_modules/@hollowverse/config/tslint/tslint.json"],
   "rules": {
     "no-submodule-imports": [false],
-    "await-promise": [true, "Bluebird"]
+    "await-promise": [true, "Bluebird"],
+    "no-multiline-string": [false]
   }
 }


### PR DESCRIPTION
This PR also includes some (technically) breaking changes to the enum types. The enum values for enum types that are not yet used on the production website are now all uppercase for consistency.

There remains a few non-uppercase enum types that cannot be changed now because they would break the website and they are stored in lowercase in the database so we'll need to figure out how to make those consistent with the other enum types.

After we complete the conversion, we should enforce uppercase for all future enum types via a linting rule.