### PR TITLE
User uppercase for enums, update ReviewStatus values, enforce new linting rules

### DIFF
--- a/.graphql-schema-linterrc
+++ b/.graphql-schema-linterrc
@@ -1,9 +1,11 @@
 {
   "rules": [
     "deprecations-have-a-reason",
+    "types-are-capitalized",
     "fields-are-camel-cased",
     "input-object-values-are-camel-cased",
     "input-object-values-have-descriptions",
-    "types-are-capitalized"
+    "types-are-capitalized",
+    "relay-connection-types-spec"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "eslint-plugin-typescript": "^0.12.0",
     "get-port": "^3.2.0",
     "graphql-code-generator": "^0.9.2",
-    "graphql-schema-linter": "^0.1.1",
+    "graphql-schema-linter": "^0.1.6",
     "graphql-tag": "^2.8.0",
     "husky": "^1.0.0-rc.1",
     "jest": "^23.1.0",

--- a/src/database/entities/EditorialSummaryNode.ts
+++ b/src/database/entities/EditorialSummaryNode.ts
@@ -5,22 +5,14 @@ import {
   ManyToOne,
   OneToMany,
 } from 'typeorm';
-import { IsNotEmpty, ValidateIf, IsUrl } from 'class-validator';
+import { IsNotEmpty, ValidateIf, IsUrl, IsIn } from 'class-validator';
 import { BaseEntity } from './BaseEntity';
 import { EditorialSummary } from './EditorialSummary';
-import { EditorialSummaryNodeType } from '../../typings/schema';
+import {
+  EditorialSummaryNodeType,
+  EditorialSummaryNodeTypeTuple,
+} from '../../typings/schema';
 import { urlValidationOptions } from '../../helpers/validation';
-
-const nodeTypes: Record<EditorialSummaryNodeType, string> = {
-  quote: '',
-  heading: '',
-  paragraph: '',
-  text: '',
-  link: '',
-  emphasis: '',
-};
-
-export type NodeType = keyof typeof nodeTypes;
 
 /**
  * Editorial content from the old Hollowverse website
@@ -39,13 +31,12 @@ export class EditorialSummaryNode extends BaseEntity {
   })
   order: number;
 
+  @IsIn(EditorialSummaryNodeTypeTuple)
   @Column({
     nullable: false,
-    type: 'enum',
-    default: null,
-    enum: Object.keys(nodeTypes),
+    type: 'varchar',
   })
-  type: NodeType;
+  type: EditorialSummaryNodeType;
 
   @Column('varchar', {
     nullable: true,

--- a/src/database/entities/NotablePersonEvent.ts
+++ b/src/database/entities/NotablePersonEvent.ts
@@ -19,6 +19,7 @@ import {
   NotablePersonEventReviewStatus,
   NotablePersonEventTypeTuple,
   NotablePersonEventReviewStatusTuple,
+  NotablePersonEventReviewStatusEnum,
 } from '../../typings/schema';
 import { urlValidationOptions } from '../../helpers/validation';
 import { transformTinyIntOrNull } from '../valueTransfomers/tinyIntOrNull';
@@ -49,9 +50,13 @@ export class NotablePersonEvent extends BaseEntity {
   })
   type: NotablePersonEventType;
 
+  @ValidateIf((_, v) => {
+    return v !== undefined;
+  })
   @IsIn(NotablePersonEventReviewStatusTuple)
   @Column({
     nullable: false,
+    default: NotablePersonEventReviewStatusEnum.NOT_REVIEWED,
     type: 'varchar',
   })
   reviewStatus: NotablePersonEventReviewStatus;

--- a/src/database/entities/NotablePersonEvent.ts
+++ b/src/database/entities/NotablePersonEvent.ts
@@ -7,7 +7,7 @@ import {
   ManyToMany,
   JoinTable,
 } from 'typeorm';
-import { IsUrl, IsNotEmpty, ValidateIf } from 'class-validator';
+import { IsUrl, IsNotEmpty, ValidateIf, IsIn } from 'class-validator';
 import { Trim } from '@hollowverse/class-sanitizer';
 import { BaseEntity } from './BaseEntity';
 import { NotablePerson } from './NotablePerson';
@@ -17,22 +17,11 @@ import { EventLabel } from './EventLabel';
 import {
   NotablePersonEventType,
   NotablePersonEventReviewStatus,
+  NotablePersonEventTypeTuple,
+  NotablePersonEventReviewStatusTuple,
 } from '../../typings/schema';
 import { urlValidationOptions } from '../../helpers/validation';
 import { transformTinyIntOrNull } from '../valueTransfomers/tinyIntOrNull';
-
-const eventTypes: Record<NotablePersonEventType, string> = {
-  quote: '',
-  donation: '',
-  appearance: '',
-};
-
-const reviewStatuses: Record<NotablePersonEventReviewStatus, string> = {
-  APPROVED: '',
-  DISAPPROVED: '',
-};
-
-export type EventType = keyof typeof eventTypes;
 
 /**
  * An event about a notable person
@@ -53,19 +42,17 @@ export class NotablePersonEvent extends BaseEntity {
   })
   isQuoteByNotablePerson: boolean | null;
 
+  @IsIn(NotablePersonEventTypeTuple)
   @Column({
     nullable: false,
-    type: 'enum',
-    default: null,
-    enum: Object.keys(eventTypes),
+    type: 'varchar',
   })
-  type: EventType;
+  type: NotablePersonEventType;
 
+  @IsIn(NotablePersonEventReviewStatusTuple)
   @Column({
     nullable: false,
-    type: 'enum',
-    default: null,
-    enum: Object.keys(reviewStatuses),
+    type: 'varchar',
   })
   reviewStatus: NotablePersonEventReviewStatus;
 

--- a/src/database/entities/User.ts
+++ b/src/database/entities/User.ts
@@ -1,17 +1,11 @@
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
-import { IsEmail, IsNotEmpty, ValidateIf } from 'class-validator';
+import { IsEmail, IsNotEmpty, ValidateIf, IsIn } from 'class-validator';
 import { Trim } from '@hollowverse/class-sanitizer';
 import { normalizeEmail, isEmail } from 'validator';
 import { BaseEntity } from './BaseEntity';
 import { NotablePersonEvent } from './NotablePersonEvent';
 import { NotablePersonEventComment } from './NotablePersonEventComment';
-import { UserRole } from '../../typings/schema';
-
-const userRoles: Record<UserRole, string> = {
-  EDITOR: '',
-  CONTRIBUTOR: '',
-  MODERATOR: '',
-};
+import { UserRole, UserRoleTuple } from '../../typings/schema';
 
 /**
  * A Hollowverse user
@@ -48,11 +42,11 @@ export class User extends BaseEntity {
   })
   comments: NotablePersonEventComment[];
 
+  @ValidateIf((_, v) => v !== null)
+  @IsIn(UserRoleTuple)
   @Column({
     nullable: true,
-    type: 'enum',
     default: null,
-    enum: Object.keys(userRoles),
   })
   role: UserRole | null;
 

--- a/src/database/entities/User.ts
+++ b/src/database/entities/User.ts
@@ -42,7 +42,9 @@ export class User extends BaseEntity {
   })
   comments: NotablePersonEventComment[];
 
-  @ValidateIf((_, v) => v !== null)
+  @ValidateIf((_, v) => {
+    return v !== undefined && v !== null;
+  })
   @IsIn(UserRoleTuple)
   @Column({
     nullable: true,

--- a/src/database/entities/User.ts
+++ b/src/database/entities/User.ts
@@ -47,6 +47,7 @@ export class User extends BaseEntity {
   @Column({
     nullable: true,
     default: null,
+    type: 'varchar',
   })
   role: UserRole | null;
 

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -52,6 +52,9 @@ enum NotablePersonEventType {
   quote
   donation
   appearance
+  QUOTE
+  DONATION
+  APPEARANCE
 }
 
 enum NotablePersonEventReviewStatus {
@@ -66,6 +69,12 @@ enum EditorialSummaryNodeType {
   text
   emphasis
   link
+  QUOTE
+  HEADING
+  PARAGRAPH
+  TEXT
+  EMPHASIS
+  LINK
 }
 
 type EditorialSummaryNode {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -58,8 +58,9 @@ enum NotablePersonEventType {
 }
 
 enum NotablePersonEventReviewStatus {
-  APPROVED
-  DISAPPROVED
+  NOT_REVIEWED
+  ALLOWED
+  REMOVED
 }
 
 enum EditorialSummaryNodeType {

--- a/src/scripts/insertMockData.ts
+++ b/src/scripts/insertMockData.ts
@@ -3,10 +3,7 @@
 import { connectionPromise } from '../database/connection';
 import { NotablePerson } from '../database/entities/NotablePerson';
 import { User } from '../database/entities/User';
-import {
-  NotablePersonEvent,
-  EventType,
-} from '../database/entities/NotablePersonEvent';
+import { NotablePersonEvent } from '../database/entities/NotablePersonEvent';
 import { NotablePersonEventComment } from '../database/entities/NotablePersonEventComment';
 import { NotablePersonLabel } from '../database/entities/NotablePersonLabel';
 import { EventLabel } from '../database/entities/EventLabel';
@@ -92,7 +89,7 @@ if (isProd === false) {
           event.id = faker.random.uuid();
           event.happenedOn = faker.date.past();
           event.postedAt = new Date();
-          event.type = faker.helpers.randomize<EventType>([
+          event.type = faker.helpers.randomize<(typeof event)['type']>([
             'donation',
             'quote',
             'appearance',

--- a/src/typings/schema.ts.all.handlebars
+++ b/src/typings/schema.ts.all.handlebars
@@ -57,6 +57,10 @@ export type {{ name }} = {{#each values }}"{{ value }}"{{#unless @last}} | {{/un
 
 export const {{ name }}Tuple: {{name}}[] = [{{#each values }}"{{ value }}"{{#unless @last}}, {{/unless}}{{/each}}];
 
+export enum {{name}}Enum {
+  {{#each values }}{{value}} = "{{ value }}",
+  {{/each}}
+}
 {{/each}}
 
 // endregion Enums

--- a/src/typings/schema.ts.all.handlebars
+++ b/src/typings/schema.ts.all.handlebars
@@ -55,6 +55,8 @@ export interface {{ toPascalCase name }}{{ toPascalCase ../name }}Args {
 /** {{ description }} */
 export type {{ name }} = {{#each values }}"{{ value }}"{{#unless @last}} | {{/unless}}{{/each}};
 
+export const {{ name }}Tuple: {{name}}[] = [{{#each values }}"{{ value }}"{{#unless @last}}, {{/unless}}{{/each}}];
+
 {{/each}}
 
 // endregion Enums

--- a/yarn.lock
+++ b/yarn.lock
@@ -3303,15 +3303,6 @@ cors@^2.8.4:
     object-assign "^4"
     vary "^1"
 
-cosmiconfig@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-3.1.0.tgz#640a94bf9847f321800403cd273af60665c73397"
-  dependencies:
-    is-directory "^0.3.1"
-    js-yaml "^3.9.0"
-    parse-json "^3.0.0"
-    require-from-string "^2.0.1"
-
 cosmiconfig@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
@@ -5188,14 +5179,14 @@ graphql-request@^1.4.0:
   dependencies:
     cross-fetch "0.0.8"
 
-graphql-schema-linter@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/graphql-schema-linter/-/graphql-schema-linter-0.1.1.tgz#bca091db7c075935764cc798377420dcebc93191"
+graphql-schema-linter@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/graphql-schema-linter/-/graphql-schema-linter-0.1.6.tgz#cc25f42443afae451ea30ff682a03bee3cb7b602"
   dependencies:
     chalk "^2.0.1"
     columnify "^1.5.4"
     commander "^2.11.0"
-    cosmiconfig "^3.1.0"
+    cosmiconfig "^4.0.0"
     figures "^2.0.0"
     glob "^7.1.2"
     graphql "^0.13.0"
@@ -8325,12 +8316,6 @@ parse-json@^2.2.0:
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
     error-ex "^1.2.0"
-
-parse-json@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-3.0.0.tgz#fa6f47b18e23826ead32f263e744d0e1e847fb13"
-  dependencies:
-    error-ex "^1.3.1"
 
 parse-json@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
* Add new versions of lowercase enum values (no breaking changes)
* Change `NotablePersonEventReviewStatus` to `ALLOWED`/`REMOVED` and add new `NOT_REVIEWED` value instead of `null`.
* Generate a new tuple array and enum object via the Handlebars template for enum types to get rid of hacky objects that we were using to collect all possible enum values.
* Switch from using MySQL native `ENUM` type to regular strings. For validation of values, use `class-validator`. This gives us more flexibility to add more enum values later without having to make database-side changes. [MySQL enums are hard to work with and provide little benefit over ORM-level validation](http://komlenic.com/244/8-reasons-why-mysqls-enum-data-type-is-evil/).
* Enforce two new schema linter rules. `relay-connection-spec-types` is extremely useful for enforcing that all connection types are compatible with the Relay spec. There is another rule that I'd like to enforce: `relay-connection-arguments-spec`, but it seems buggy currently. Tracking issue: https://github.com/cjoudrey/graphql-schema-linter/issues/148?ts=2


Changes to the schema require manual updates which I'm currently working on.

After this is finished, we'll need to update the frontend to handle both uppercase and lowercase variants. After that, we can go ahead and update the data in the database to make all values uppercase.